### PR TITLE
Support user defined storage file name

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -1,26 +1,36 @@
 commands:
   persist-env:
     description: Persist all environment variables
+    parameters:
+      file-name:
+        type: string
+        description: The name of the file used for storage within the workspace
+        default: .env-to-persist
     steps:
       - run:
           name: Touch file
-          command: touch /tmp/.env-to-persist
+          command: touch /tmp/<< parameters.file-name >>
       - persist_to_workspace:
           root: /tmp
           paths:
-            - .env-to-persist
+            - << parameters.file-name >>
 
   attach-env:
     description: Attach the environment variables previously stored
+    parameters:
+      file-name:
+        type: string
+        description: The name of the file used for storage within the workspace
+        default: .env-to-persist
     steps:
       - attach_workspace:
           at: /tmp
       - run:
           name: Touch file
-          command: touch /tmp/.env-to-persist
+          command: touch /tmp/<< parameters.file-name >>
       - run:
           name: Append to bash environment file
-          command: cat /tmp/.env-to-persist >> $BASH_ENV
+          command: cat /tmp/<< parameters.file-name >> >> $BASH_ENV
 
   set-env-var:
     description: Set an environment variable
@@ -99,4 +109,4 @@ examples:
                 requires:
                   - build
 description: Persist environment variables between jobs.
-version: 2.1
+version: 2.2

--- a/orb.yml
+++ b/orb.yml
@@ -109,4 +109,4 @@ examples:
                 requires:
                   - build
 description: Persist environment variables between jobs.
-version: 2.2
+version: 2.1


### PR DESCRIPTION
This PR adds support for user defined file names allowing users to avoid the concurrent upstream jobs persisting to the same file shown below.

```
Concurrent upstream jobs persisted the same file(s) into the workspace:
  - .env-to-persist
```

I was unsure how to best test this but it looks like you've got a pipeline to test new versions under a dev tag. Will try that once published  